### PR TITLE
Change the word 'swimmed' to 'swum'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Example
 import { Trait, Derive } from "@rse/traits"
 
 const Swim = Trait((base) => class Swim extends base {
-    swimmed = 0
-    swim () { return this.swimmed++ }
+    swum = 0
+    swim () { return this.swum++ }
 })
 const Walk = Trait((base) => class Walk extends base {
     walked = 0


### PR DESCRIPTION
The word "swimmed" is incorrect and should be replaced with "swum", which is the proper past participle of "swim." While you could argue that "swam" might also work, using the perfect tense is more appropriate in this example. In any case, "swimmed" is not a valid word and should be corrected.

[Reference](https://www.wordreference.com/conj/enverbs.aspx?v=swim)